### PR TITLE
Improved multiplatform support

### DIFF
--- a/src/content-scripts/page-script.js
+++ b/src/content-scripts/page-script.js
@@ -449,7 +449,7 @@ function onSearchEngineClick(engineObject, settings)
 				hostname: window.location ? window.location.hostname : "",
 			};
 
-			if (ev.ctrlKey) {
+			if (ev[selectionchange.modifier]) {
 				message.clickType = "ctrlClick";
 			} else if (ev.which === 1) {
 				message.clickType = "leftClick";

--- a/src/content-scripts/selectionchange.js
+++ b/src/content-scripts/selectionchange.js
@@ -34,7 +34,8 @@ var selectionchange = (function (undefined) {
 				d.removeEventListener('mouseup', onMouseUp, true);
 				// d.defaultView.removeEventListener('focus', onFocus, true);
 			}
-		}
+		},
+		modifier: SELECT_ALL_MODIFIER
 	};
 
 	function getSelectionRange(doc) {


### PR DESCRIPTION
I think the only commit is pretty much self-explainatory.

On mac ```ctrl+click``` only spawn the contextual menu, and the TrackPad cannot emulate the middleClick, so a set of really nice features wasn't working on mouseless Macs.

I hope you like the way I implemented the fix. It seemed to me the more modular way.