### PR TITLE
Support div icon in settings

### DIFF
--- a/src/content-scripts/page-script.js
+++ b/src/content-scripts/page-script.js
@@ -274,17 +274,13 @@ padding: ${3 + settings.popupItemVerticalPadding}px ${settings.popupItemPadding}
 		let engine = searchEngines[i];
 
 		if (engine.type === "sss") {
-			// icon paths should not be hardcoded here, but getting them from bg script is cumbersome
-			if (engine.id === "copyToClipboard") {
-				let iconImgSource = browser.extension.getURL("res/sss-engine-icons/copy.svg");
-				setupEngineIcon(engine, iconImgSource, "Copy to clipboard", iconCssText, settings);
-			}
-			else if (engine.id === "openAsLink") {
-				let iconImgSource = browser.extension.getURL("res/sss-engine-icons/open-link.svg");
-				setupEngineIcon(engine, iconImgSource, "Open as link", iconCssText, settings);
-			}
-			else if (engine.id === "separator") {
-				setupSeparatorIcon(settings);
+			let sssEngine = settings.sssIcons[engine.id]
+
+			if (sssEngine.iconPath) {
+				let iconImgSource = browser.extension.getURL(sssEngine.iconPath);
+				setupEngineIcon(engine, iconImgSource, sssEngine.description, iconCssText, popup, settings);
+			} else if (sssEngine.divCSS) {
+				setupEngineDiv(sssEngine.divCSS, popup, settings);
 			}
 		} else {
 			let iconImgSource;
@@ -296,7 +292,7 @@ padding: ${3 + settings.popupItemVerticalPadding}px ${settings.popupItemPadding}
 				iconImgSource = cachedIcon ? cachedIcon : engine.iconUrl;	// should have cached icon, but if not (for some reason) fall back to URL
 			}
 
-			setupEngineIcon(engine, iconImgSource, engine.name, iconCssText, settings);
+			setupEngineIcon(engine, iconImgSource, engine.name, iconCssText, popup, settings);
 		}
 	}
 
@@ -312,7 +308,7 @@ padding: ${3 + settings.popupItemVerticalPadding}px ${settings.popupItemPadding}
 	}
 }
 
-function setupEngineIcon(engine, iconImgSource, iconTitle, iconCssText, settings)
+function setupEngineIcon(engine, iconImgSource, iconTitle, iconCssText, parent, settings)
 {
 	let icon = document.createElement("img");
 	icon.setAttribute("src", iconImgSource);
@@ -352,24 +348,18 @@ function setupEngineIcon(engine, iconImgSource, iconTitle, iconCssText, settings
 	});
 	icon.ondragstart = function() { return false; };	// disable dragging popup images
 
-	popup.appendChild(icon);
+	parent.appendChild(icon);
 }
 
-function setupSeparatorIcon(settings)
+function setupEngineDiv(divCSS, parent, settings)
 {
 	let div = document.createElement("div");
 
-	div.style.cssText =
-`border-left: rgb(228, 227, 227) 1px solid;
-width: 1px;
-height: 24px;
-position: relative;
-display: inline-block;
-vertical-align: unset;
-box-shadow: rgb(250, 250, 250) -1px 0px 0px 0px;
-margin: ${3 + settings.popupItemVerticalPadding}px 10px;`;
+	div.style.cssText = divCSS
+	div.style.marginBottom =  (3 + settings.popupItemVerticalPadding) + "px";
+	div.style.marginTop =  (3 + settings.popupItemVerticalPadding) + "px";
 
-	popup.appendChild(div);
+	parent.appendChild(div);
 }
 
 function setPopupPositionAndSize(popup, nEngines, settings)

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -679,24 +679,56 @@ function addSearchEngine(engine, i)
 
 	cell = document.createElement("td");
 	cell.className = "engine-icon-img";
-	let icon = document.createElement("img");
+	let icon
 
 	if (engine.type === "sss") {
-		icon.src = browser.extension.getURL(mainScript.getSssIcon(engine.id).iconPath);
-	} else if (engine.iconUrl.startsWith("data:")) {
-		icon.src = engine.iconUrl;
-	} else if (settings.searchEnginesCache[engine.iconUrl] === undefined && engine.iconUrl) {
-		icon.src = engine.iconUrl;
-		getDataUriFromImgUrl(engine.iconUrl, function(base64Img) {
-			icon.src = base64Img;
-			settings.searchEnginesCache[engine.iconUrl] = base64Img;
-			saveSettings({ searchEnginesCache: settings.searchEnginesCache });
-		});
-	} else {
-		icon.src = settings.searchEnginesCache[engine.iconUrl];
-	}
-	cell.appendChild(icon);
+
+		let sssEngine = mainScript.getSssIcon(engine.id)
+
+		if (sssEngine.iconPath) {
+			let iconImgSource = browser.extension.getURL(sssEngine.iconPath);
+			icon = setupEngineIcon(sssEngine, iconImgSource, sssEngine.description, '', cell, settings);
+		} else if (sssEngine.divCSS) {
+			icon = setupEngineDiv(sssEngine.divCSS, cell, settings);
+		}
+
+	} else
+		icon = setupEngineIcon(engine, engine.iconUrl, engine.name, '', cell, settings);
+
 	row.appendChild(cell);
+
+	function setupEngineIcon(engine, iconImgSource, iconTitle, iconCssText, parent, settings)
+	{
+		let icon = document.createElement("img");
+
+		if (iconImgSource.startsWith("data:")) {
+			icon.src = iconImgSource
+		} else if (settings.searchEnginesCache[iconImgSource] === undefined && iconImgSource) {
+		 	icon.src = iconImgSource;
+			getDataUriFromImgUrl(iconImgSource, function(base64Img) {
+				icon.src = base64Img;
+				settings.searchEnginesCache[iconImgSource] = base64Img;
+				saveSettings({ searchEnginesCache: settings.searchEnginesCache });
+			});
+		} else {
+			icon.src = settings.searchEnginesCache[iconImgSource];
+		}
+
+		parent.appendChild(icon);
+		return icon
+	}
+
+	function setupEngineDiv(divCSS, parent, settings)
+	{
+		let div = document.createElement("div");
+
+		div.style.cssText = divCSS
+		div.style.marginBottom = "0px";
+		div.style.marginTop = "0px";
+
+		parent.appendChild(div);
+		return div
+	}
 
 	if (engine.type === "sss")
 	{

--- a/src/swift-selection-search.js
+++ b/src/swift-selection-search.js
@@ -51,7 +51,15 @@ const consts = {
 		separator: {
 			name: "Separator",
 			description: '[SSS] Adds a separator.',
-			iconPath: "res/sss-engine-icons/separator.png",
+			divCSS: `border-left: rgb(228, 227, 227) 1px solid;
+			width: 1px;
+			height: 24px;
+			margin: 10px;
+			position: relative;
+			display: inline-block;
+			vertical-align: unset;
+			box-shadow: rgb(250, 250, 250) -1px 0px 0px 0px;
+			`,
 		}
 	}
 };
@@ -88,6 +96,8 @@ const defaultSettings = {
 	enableEnginesInContextMenu: true,
 	contextMenuItemBehaviour: consts.MouseButtonBehaviour_NewBgTab,
 	contextMenuEnginesFilter: consts.ContextMenuEnginesFilter_SameAsPopup,
+
+	sssIcons: consts.sssIcons,
 
 	searchEngines: [
 		{


### PR DESCRIPTION
Hello @CanisLupus 

This PR aims to finish what has been started with #79 and focus on fixing this:

> Still have to decide about the separator icon too. I would prefer to unify the icon in the settings page and popup to both use either CSS or the image. I'm leaning toward CSS(*), since someone will likely request options to change the separator. ;)

Here I mostly refactored stuff generalizing a bit here and there, with some copy&paste from page-script to settings.

The most breaking change is that in 507e610 I added the ```sssIcons``` object to the storage, in a pretty naive way too. I'm almost sure that it's not a problem, but maybe some test on a not-fresh installation should be done.

That said, I think the result is pure gold:

<img width="870" alt="schermata 2018-04-15 alle 00 21 13" src="https://user-images.githubusercontent.com/6209647/38773422-285f9e54-404c-11e8-892b-3fd29afb4f0c.png">

> A CSS separator will require a few things more to be consistent with other options, however, such as respecting the icon size setting and being correctly included in popup width calculations.

The main ```sssIcons``` object act as a templating system now, so I found to be very easy to override properties in ```setupEngineDiv``` to adapt to the context, maybe injecting future settings handlers for full user customisation.

What I like the most is that now if you want to change the appearence of the icons you can do it with a one time modification of the CSS/iconPath in the main template in ```sssIcons```.

Also it seems to me incredibly scalable, if in the future you will want to add a new div-based element.