### PR TITLE
Fix os information retrieving method

### DIFF
--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -304,26 +304,28 @@ function onPageLoaded()
 
 	let platformSpecificElements;
 
-	switch (browser.runtime.PlatformOs)
-	{
-		case "android":
-		case "cros":
-		case "linux":
-		case "openbsd":
-			platformSpecificElements = document.getElementsByClassName("os-linux");
-			break;
-		case "mac":
-			platformSpecificElements = document.getElementsByClassName("os-mac");
-			break;
-		case "win":
-		default:
-			platformSpecificElements = document.getElementsByClassName("os-windows");
-			break;
-	}
+	browser.runtime.getPlatformInfo().then(info => {
+		switch (info.os)
+		{
+			case "android":
+			case "cros":
+			case "linux":
+			case "openbsd":
+				platformSpecificElements = document.getElementsByClassName("os-linux");
+				break;
+			case "mac":
+				platformSpecificElements = document.getElementsByClassName("os-mac");
+				break;
+			case "win":
+			default:
+				platformSpecificElements = document.getElementsByClassName("os-windows");
+				break;
+		}
 
-	for (let elem of platformSpecificElements) {
-		elem.style.display = "inline";
-	}
+		for (let elem of platformSpecificElements) {
+			elem.style.display = "inline";
+		}
+	})
 
 	// general layout (changes if page is embedded or separate)
 


### PR DESCRIPTION
Hello @CanisLupus ,
on my Mac (and linux machines, too) the only information available appeared to refer to Windows (after 70ede7e4e06930c9e018cc6ac5f69e1a63c67a58).

The problem was that ```browser.runtime.PlatformOs``` is not a variable, but a Type constant that provide the typing info for the ```os``` property of the object returned by ```browser.runtime.getPlatformInfo``` (and maybe other os-related objects).

```console.log(browser.runtime.PlatformOs)``` returns a dictionary kind of object, and never a single string.

The documentation is written awefully bad, in a way that is easy to misunderstand.

For references:
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/PlatformOs
https://developer.chrome.com/extensions/runtime#type-PlatformOs