### PR TITLE
Implements shortcut feature (related to #149)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Thumbs.db
+.vscode
+/node_modules
+*.js
+
+!/src/libs/*
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-Thumbs.db
-.vscode
-/node_modules
-*.js
-
-!/src/libs/*

--- a/src/content-scripts/page-script.ts
+++ b/src/content-scripts/page-script.ts
@@ -315,15 +315,6 @@ namespace ContentScript
 	// shows the popup if the conditions are proper, according to settings
 	function tryShowPopup(ev: Event, isForced: boolean)
 	{
-		// Disable shortcuts temporarily when in an editable field
-		// This is to avoid a search from happening when the user highlights some text
-		// just to replace it with another one that starts with a character that is also a shortcut.
-		if (selection.isInEditableField ||
-			isInEditableField(selection.selection.anchorNode)) {
-				if (activationSettings.useEngineShortcut) {
-					settings.useEngineShortcut = false;
-				}
-			}
 
 		if (settings.popupOpenBehaviour === SSS.PopupOpenBehaviour.Auto)
 		{
@@ -467,7 +458,9 @@ namespace ContentScript
 		// Check if the user pressed a shortcut
 		if (settings.useEngineShortcut
 			&& (!ev.altKey && !ev.ctrlKey && !ev.metaKey && !ev.shiftKey) // modifiers are not supported right now
-			&& ev.originalTarget.className !== "sss-input-field") { // make sure we're not inside the popup's text field
+			&& ev.originalTarget.className !== "sss-input-field" // make sure we're not inside the popup's text field
+			&& !selection.isInEditableField
+			&& !isInEditableField(selection.selection.anchorNode)) { // shortcuts are disabled in editable fields
 
 			// The popup must be visible, unless 'Always enable shortcuts' is checked and there's a selection
 			if (popup.content.style.display !== "inline-block"

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -207,6 +207,16 @@ or loading the user settings, is provided by settings.ts and possibly some helpe
 	.engine-is-enabled,
 	.engine-is-enabled-in-context-menu,
 	.engine-icon-img,
+	.engine-shortcut {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 30px;
+	}
+	.engine-shortcut input {
+		text-transform: uppercase;
+		text-align: center;
+	}
 	.engine-delete {
 		display: flex;
 		align-items: center;
@@ -498,6 +508,7 @@ or loading the user settings, is provided by settings.ts and possibly some helpe
 							<div class="engine-name">Name</div>
 							<div class="engine-search-link">Search URL</div>
 							<div class="engine-icon-link">Icon URL</div>
+							<div class="engine-shortcut" title="Shortcut">S.</div>
 							<div class="engine-delete"></div>
 						</div>
 					</div>
@@ -669,6 +680,23 @@ or loading the user settings, is provided by settings.ts and possibly some helpe
 			</div>
 
 			<div class="setting">
+				<div class="setting-name">When using a shortcut</div>
+				<div class="setting-value">
+					<select class="setting-input" name="shortcutBehaviour">
+						<option value="this-tab">Open in this tab</option>
+						<option value="new-tab">Open in new tab</option>
+						<option value="new-bg-tab">Open in new background tab</option>
+						<option value="new-tab-next">Open in new tab (next to current tab)</option>
+						<option value="new-bg-tab-next">Open in new background tab (next to current tab)</option>
+						<option value="new-window">Open in new window</option>
+						<option value="new-bg-window">(unsupported in Firefox) Open in new background window</option>
+					</select>
+				</div>
+				<div class="setting-description">What to do when searching via shortcut. Also applies when selecting the engine with the TAB key.</div>
+				<div class="setting-reset"><input type="button" value="Default"></div>
+			</div>
+
+			<div class="setting">
 				<div class="setting-name">Allow popup on editable fields</div>
 				<div class="setting-value">
 					<input class="setting-input" type="checkbox" name="allowPopupOnEditableFields" autocomplete="off">
@@ -700,7 +728,25 @@ or loading the user settings, is provided by settings.ts and possibly some helpe
 				<div class="setting-value">
 					<input class="setting-input" type="checkbox" name="hidePopupOnSearch" autocomplete="off" checked>
 				</div>
-				<div class="setting-description">Hides the popup when a search engine is clicked.</div>
+				<div class="setting-description">Hides the popup when a search engine is clicked. This also applies when using shortcuts.</div>
+				<div class="setting-reset"><input type="button" value="Default"></div>
+			</div>
+
+			<div class="setting">
+				<div class="setting-name">Use shortcuts for the search engines</div>
+				<div class="setting-value">
+					<input class="setting-input" type="checkbox" name="useEngineShortcut" autocomplete="off" checked>
+				</div>
+				<div class="setting-description">Search using a shortcut assigned to an engine.</div>
+				<div class="setting-reset"><input type="button" value="Default"></div>
+			</div>
+
+			<div class="setting hidden indent">
+				<div class="setting-name">Always enable shortcuts</div>
+				<div class="setting-value">
+					<input class="setting-input" type="checkbox" name="useEngineShortcutWithoutPopup" autocomplete="off" checked>
+				</div>
+				<div class="setting-description">Shortcuts work whether the popup is visible or not.</div>
 				<div class="setting-reset"><input type="button" value="Default"></div>
 			</div>
 


### PR DESCRIPTION
- Adds an additional field on the 'Search engines' section of the settings page for each engine, which will hold a single character to be used as a shortcut for that engine. This character can either be a letter, number or any other that doesn't require a modifier (e.g. `Alt, Ctrl, Shift`) to be typed.

- To activate the shortcuts the user has to check the option _Use shortcuts for the search engines_. Upon enabling this setting, another option named _Always enable shortcuts_ will appear, which, if checked, enables shortcuts even without the popup showing up.

- Shortcuts don't work on editable fields.

- The user can control how the search will be carried out by selecting the opening behaviour under the option _When using a shortcut_.

- Additionally, the user can select the engine by using the `TAB` key and hitting `Enter`. In this case, the same opening behaviour used for shortcuts will apply.