### PR TITLE
Add transparent background to popup's text field

### DIFF
--- a/src/content-scripts/page-script.ts
+++ b/src/content-scripts/page-script.ts
@@ -759,6 +759,9 @@ namespace PopupCreator
 					border-radius: ${settings.popupBorderRadius}px;
 					padding: 4px 7px;
 					margin: 4px 0px 2px 0px;
+					background: transparent;
+					color:white;
+					mix-blend-mode: exclusion;
 				}
 
 				.sss-input-field:hover {


### PR DESCRIPTION
Hey Daniel! This is just something I did awhile ago. A minor stylistic modification to make the popup's text field match the background color of the popup. Currently, it stays white when the user changes the said color:

![image](https://user-images.githubusercontent.com/8989075/102014718-3617f480-3d36-11eb-9de5-4021a3a1d4d9.png)

With this modification, it would look like this:

![image](https://user-images.githubusercontent.com/8989075/102014743-6069b200-3d36-11eb-9142-078678b37e6f.png)

With the help of the `mix-blend-mode` property we shouldn't worry about the text color since it will automatically contrast with the background. 

I'm personally not using the popup lately -  only shortcuts :) - but I thought it would be an improvement. If you think it should stay as it is, no problem.

